### PR TITLE
makes the gilab-ce formula work on ubuntu again

### DIFF
--- a/gitlab-ce/apt.sls
+++ b/gitlab-ce/apt.sls
@@ -1,8 +1,7 @@
 {% from "gitlab-ce/map.jinja" import gitlab with context %}
-{% set os = grains.osfullname|lower %}
 
 gitlab-ce-pkgrepo:
   pkgrepo.managed:
-    - name: deb https://packages.gitlab.com/gitlab/gitlab-ce/{{ os }}/ {{ gitlab.repodist }} main
+    - name: deb https://packages.gitlab.com/gitlab/gitlab-ce/{{ grains['os']|lower }}/ {{ grains['oscodename'] }} main
     - file: {{ gitlab.repofile }}
     - key_url: {{ gitlab.gpgkey_url }}

--- a/gitlab-ce/map.jinja
+++ b/gitlab-ce/map.jinja
@@ -1,6 +1,6 @@
 {% set gitlab = salt['grains.filter_by']({
   'Debian': {
-    'gpgkey_url': 'https://packages.gitlab.com/gpg.key',
+    'gpgkey_url': 'https://packages.gitlab.com/gitlab/gitlab-ce/gpgkey',
     'repodist': salt['grains.filter_by']({
       'wheezy': 'wheezy',
       'jessie': 'jessie',
@@ -11,14 +11,15 @@
       'trusty': 'trusty',
       'utopic': 'trusty',
       'vivid': 'trusty',
-      'wily': 'trusty'
+      'wily': 'trusty',
+      'xenial': 'xenial'
     }, grain='oscodename'),
     'repofile': '/etc/apt/sources.list.d/gitlab-ce.list',
     'pkg_name': 'gitlab-ce',
     'service_name': 'gitlab-runsvdir'
   },
   'RedHat': {
-    'gpgkey_url': 'https://packages.gitlab.com/gpg.key',
+    'gpgkey_url': 'https://packages.gitlab.com/gitlab/gitlab-ce/gpgkey',
     'repodist': salt['grains.filter_by']({
       'CentOS-6': '6',
       'CentOS Linux-7': '7'


### PR DESCRIPTION
Hi, Thank you for writing this great formula, I have put it to good use multiple times.

Sadly the repository this Formula depended on, was changed by Gitlab some time ago, this commit/merge makes it so that the new address is used.

I only tested it with Ubuntu, it might still be broken on RHEL based Systems.

Greetings Ham5ter. 